### PR TITLE
Fix to #55 - text_encoder_device returns the device type as CPU.

### DIFF
--- a/joy_caption_two_node.py
+++ b/joy_caption_two_node.py
@@ -241,8 +241,8 @@ class Joy_caption_two_load:
 
     def __init__(self):
         self.model = None
-        self.load_device = comfy.model_management.text_encoder_device()
-        self.offload_device = comfy.model_management.text_encoder_offload_device()
+        self.load_device = comfy.model_management.get_torch_device()
+        self.offload_device = comfy.model_management.unet_offload_device()
         self.pipeline = JoyTwoPipeline(self.load_device, self.offload_device)
         self.pipeline.parent = self
 


### PR DESCRIPTION
Fix to [#55 ](https://github.com/EvilBT/ComfyUI_SLK_joy_caption_two/issues/55) caused by text_encoder_device function returns the device type as CPU. Modify the device retrieval function (get_torch_device) to accurately determine the device type.